### PR TITLE
Always call Segment's analytics.debug so that it can be disabled too

### DIFF
--- a/src/modules/SegmentModule.js
+++ b/src/modules/SegmentModule.js
@@ -25,9 +25,7 @@ export default class SegmentModule extends BasicModule {
 
     // init
     analytics.load(initConf.token)
-    if(this.config.debug) {
-      analytics.debug()
-    }
+    analytics.debug(Boolean(this.config.debug))
   }
 
   /**


### PR DESCRIPTION
Otherwise it follows what's set locally and if you ever set it to true, you can't disable it without going around the plugin