### PR TITLE
move babel-preset-env from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-loader": "^6.2.7",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-2": "^6.24.1",
     "vue": "^2.3.4",
     "vue-loader": "^11.3.4",
@@ -45,8 +46,5 @@
     "Vue2",
     "vue",
     "google"
-  ],
-  "dependencies": {
-    "babel-preset-env": "^1.6.1"
-  }
+  ]
 }


### PR DESCRIPTION
This package was installing `babel-preset-env` (and it's dependencies) in production, where it's actually only used in development to build the package and demos.