### PR TITLE
params on GA trackTiming only work with this for some reason

### DIFF
--- a/src/modules/GAModule.js
+++ b/src/modules/GAModule.js
@@ -141,7 +141,7 @@ export default class GAModule extends BasicModule {
    * @param {number} timingValue - The number of milliseconds in elapsed time to report to Google Analytics (e.g. 20).
    * @param {string|null} timingLabel -  A string that can be used to add flexibility in visualizing user timings in the reports (e.g. 'Google CDN').
    */
-  trackTiming (timingCategory, timingVar, timingValue, timingLabel = null) {
+  trackTiming ({timingCategory, timingVar, timingValue, timingLabel}) {
     if (this.config.debug) {
       logDebug({timingCategory, timingVar, timingValue, timingLabel})
     }


### PR DESCRIPTION
I tried both ways of sending params. this was the only way i could get it to work. 