### PR TITLE
feat: Add anonymizeIp to Google Analytics

### DIFF
--- a/src/modules/GAModule.js
+++ b/src/modules/GAModule.js
@@ -56,6 +56,10 @@ export default class GAModule extends BasicModule {
         ga('require', 'ecommerce')
       }
 
+      // anonymizeIp
+      if (initConf['anonymizeIp']) {
+        ga('set', 'anonymizeIp', true);
+      }
   }
 
 


### PR DESCRIPTION
This is needed to easily configure Google Analytics to comply with GDPR's IP anonymity requirements.

https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization
